### PR TITLE
Add a shell.nix and describe how to use Nix to build and run in emulator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,35 @@ Skunk is an app for the [Pebble Smartwatch](https://getpebble.com) that allows e
 Based on [PebbleBucks 3.0 by a2](https://github.com/a2/PebbleBucks), [PebbleBucks 2.0 by Neal](https://github.com/Neal/PebbleBucks), and the [original PebbleBucks by Matt Donders](https://github.com/mattdonders/PebbleBucks).
 
 Config is handled via a Ruby web app, [unlobito/skunk-config](https://github.com/unlobito/skunk-config)
+
+Building and testing with Nix
+-----------------------------
+
+This project contains a [pebble.nix](https://github.com/Sorixelle/pebble.nix)
+setup that can be used for building and testing. Builds are also automated
+using GitHub Actions.
+
+Assuming you have Nix installed, building is as simple as
+
+```
+$ nix-build
+[...]
+/nix/store/28ky82g54l35yysrwz79hly84pj4g6qj-skunk-arm-none-eabi
+```
+
+a `.pbw` and an appstore bundle are output to that directory, which is also
+provided as a `./result` symlink.
+
+For running the Pebble SDK directly for use with the Pebble emulator,
+`nix-shell` can be used:
+
+```
+$ nix-shell
+
+[nix-shell]$ pebble install --emulator basalt
+Installing app...
+App install succeeded.
+
+[nix-shell]$ pebble emu-app-config
+[Browser opens]
+```

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { pebbleDotNixSrc ? builtins.fetchTarball {
-    url = "https://github.com/Sorixelle/pebble.nix/archive/a7be1fd6523b32f176a9558c7719beab94f9ba1c.tar.gz";
-    sha256 = "1x8izcv77biwx8l8ic57vfz72yg9p4v1k36f1z97lcl7631vyhy7";
+    url = "https://github.com/Sorixelle/pebble.nix/archive/24c445d0766573f7b09982b5ff3cedf9622c2723.tar.gz";
+    sha256 = "1cnbz4d4r8b5gpvc45dmgj1pj24qxdry6xh4rrikqrdjialfvq6w";
   }
 , pebbleDotNix ? import pebbleDotNixSrc
 , packageJSON ? builtins.fromJSON (builtins.readFile ./package.json)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+{ pebbleDotNix ? null, pebbleDotNixSrc ? null }@args:
+
+(import ./. args).devShell


### PR DESCRIPTION
This updates the version of pebble.nix to accommodate my most recent change to fix downloading pebble-qemu.