### PR TITLE
Generalize Pebble screen size, add support for emery and gabbro (Pebble Time 2, Pebble Round 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
         "targetPlatforms": [
             "aplite",
             "basalt",
-            "chalk"
+            "chalk",
+            "emery",
+            "gabbro"
         ],
         "uuid": "1e420b43-63be-45f7-822c-2a7d57a55384",
         "watchapp": {

--- a/src/card_layer.c
+++ b/src/card_layer.c
@@ -29,14 +29,14 @@ CardLayer *card_layer_create(GRect frame) {
     layer_set_update_proc(card_layer->layer, background_update_proc);
     *(CardLayer **)layer_get_data(card_layer->layer) = card_layer;
     
-    card_layer->name_background_layer = layer_create(GRect(0, 0, PEBBLE_WIDTH, CARD_LAYER_NAME_HEIGHT));
+    card_layer->name_background_layer = layer_create(GRect(0, 0, screen.size.w, CARD_LAYER_NAME_HEIGHT));
     layer_set_update_proc(card_layer->name_background_layer, name_background_update_proc);
     layer_add_child(card_layer->layer, (Layer *)card_layer->name_background_layer);
     int16_t text_y = (CARD_LAYER_NAME_HEIGHT - TEXT_HEIGHT) / 2;
 #ifdef PBL_ROUND
     text_y += 4; // Magic number to avoid round screen border
 #endif
-    card_layer->name_text_layer = text_layer_create(GRect(0, text_y, PEBBLE_WIDTH, TEXT_HEIGHT));
+    card_layer->name_text_layer = text_layer_create(GRect(0, text_y, screen.size.w, TEXT_HEIGHT));
     text_layer_set_background_color(card_layer->name_text_layer, GColorBlack);
     text_layer_set_font(card_layer->name_text_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD));
     text_layer_set_overflow_mode(card_layer->name_text_layer, GTextOverflowModeTrailingEllipsis);
@@ -51,7 +51,7 @@ CardLayer *card_layer_create(GRect frame) {
 #endif
 
 
-    card_layer->value_text_layer = text_layer_create(GRect(0, frame.size.h - CARD_LAYER_VALUE_HEIGHT, PEBBLE_WIDTH, CARD_LAYER_VALUE_HEIGHT));
+    card_layer->value_text_layer = text_layer_create(GRect(0, frame.size.h - CARD_LAYER_VALUE_HEIGHT, screen.size.w, CARD_LAYER_VALUE_HEIGHT));
     text_layer_set_background_color(card_layer->value_text_layer, GColorWhite);
     text_layer_set_font(card_layer->value_text_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD));
     text_layer_set_overflow_mode(card_layer->value_text_layer, GTextOverflowModeTrailingEllipsis);
@@ -87,20 +87,20 @@ static void draw_barcode_matrix(CardLayer *card_layer, GContext* ctx) {
 
     // name_text_layer and pager_layer need to be subtracted from the pebble height
     // as does twice the WHITE_BORDER
-    const int16_t MAX_HEIGHT = PEBBLE_HEIGHT - CARD_LAYER_NAME_HEIGHT - PAGER_LAYER_HEIGHT;
+    const int16_t MAX_HEIGHT = screen.size.h - CARD_LAYER_NAME_HEIGHT - PAGER_LAYER_HEIGHT;
 
     // The mid point between the black border at the top (name_layer) and at the bottom (pager_layer)
     // is not exactly in the middle of the screen
-    const int16_t MID_HEIGHT = (PEBBLE_HEIGHT - CARD_LAYER_NAME_HEIGHT - PAGER_LAYER_HEIGHT) / 2 + CARD_LAYER_NAME_HEIGHT;
+    const int16_t MID_HEIGHT = (screen.size.h - CARD_LAYER_NAME_HEIGHT - PAGER_LAYER_HEIGHT) / 2 + CARD_LAYER_NAME_HEIGHT;
     
-    const int16_t MID_WIDTH = PEBBLE_WIDTH / 2;
+    const int16_t MID_WIDTH = screen.size.w / 2;
     
     const int16_t CONTENT_MARGIN = 1;
 
     // Non-linear barcodes are scaled to save persistent storage space. Dynamically calculate
     // the maximum integer scaling factor, keep a white border of 1 units around.
 
-    const int16_t SCALING_FACTOR_X = PEBBLE_WIDTH / (card_layer->barcode_width + CONTENT_MARGIN * 2);
+    const int16_t SCALING_FACTOR_X = screen.size.w / (card_layer->barcode_width + CONTENT_MARGIN * 2);
     const int16_t SCALING_FACTOR_Y = MAX_HEIGHT / (card_layer->barcode_height + CONTENT_MARGIN * 2);
 
     // actual scaling factor is the least of x and y scaling, but at least 1
@@ -150,11 +150,11 @@ static void draw_barcode_linear(CardLayer *card_layer, GContext* ctx) {
     const int16_t CONTENT_MARGIN = 1;
 
     // Try to do an integer scale if possible, keep white border of 1 unit on each side
-    const int16_t SCALING_FACTOR_X = PEBBLE_WIDTH / (card_layer->barcode_width + CONTENT_MARGIN * 2);
+    const int16_t SCALING_FACTOR_X = screen.size.w / (card_layer->barcode_width + CONTENT_MARGIN * 2);
     const int16_t SCALING_FACTOR = MAX( SCALING_FACTOR_X, 1);
 
-    const int16_t first_point_x = PEBBLE_WIDTH / 2 - (SCALING_FACTOR * card_layer->barcode_width) / 2;
-    const int16_t first_point_y = PEBBLE_HEIGHT / 2 - card_layer->barcode_height / 2;
+    const int16_t first_point_x = screen.size.w / 2 - (SCALING_FACTOR * card_layer->barcode_width) / 2;
+    const int16_t first_point_y = screen.size.h / 2 - card_layer->barcode_height / 2;
 
     // The comparison part of this loop adds 7 to the barcode width to allow C
     // to ceil the byte count. Since the server will always pad incomplete bytes

--- a/src/defines.h
+++ b/src/defines.h
@@ -1,12 +1,6 @@
 #pragma once
 
-#ifdef PBL_ROUND
-#define PEBBLE_HEIGHT 180
-#define PEBBLE_WIDTH 180
-#else
-#define PEBBLE_HEIGHT 168
-#define PEBBLE_WIDTH 144
-#endif
+#include <pebble.h>
 
 #define TEXT_MARGIN 4
 #define TEXT_HEIGHT 22
@@ -59,5 +53,7 @@ enum {
     BARCODE_LINEAR                     = 1,
 };
 
+
+GRect screen;
 
 #define STORAGE_CARD_VALUE(NAME, INDEX) (20 + 10 * (INDEX) + (STORAGE_CARD_ ## NAME ## _OFFSET))

--- a/src/main.c
+++ b/src/main.c
@@ -98,6 +98,9 @@ static void upgrade(void) {
 }
 
 static void window_load(Window *window) {
+    Layer *window_layer = window_get_root_layer(window);
+    screen = layer_get_bounds(window_layer);
+
     card_layer_init();
     pager_layer_init();
     refresh_layer_init();
@@ -299,7 +302,7 @@ static void app_message_send_fetch_data(void) {
 }
 
 static void card_layer_init(void) {
-    card_layer = card_layer_create(GRect(0, 0, PEBBLE_WIDTH, PEBBLE_HEIGHT - PAGER_LAYER_HEIGHT));
+    card_layer = card_layer_create(GRect(0, 0, screen.size.w, screen.size.h - PAGER_LAYER_HEIGHT));
     card_layer_set_index(card_layer, 0);
 
     Layer *root_layer = window_get_root_layer(window);
@@ -311,7 +314,7 @@ static void card_layer_deinit(void) {
 }
 
 static void pager_layer_init(void) {
-    pager_layer = pager_layer_create(GRect(0, PEBBLE_HEIGHT - PAGER_LAYER_HEIGHT, PEBBLE_WIDTH, PAGER_LAYER_HEIGHT));
+    pager_layer = pager_layer_create(GRect(0, screen.size.h - PAGER_LAYER_HEIGHT, screen.size.w, PAGER_LAYER_HEIGHT));
     pager_layer_set_values(pager_layer, 0, 1);
 
     Layer *root_layer = window_get_root_layer(window);
@@ -323,7 +326,7 @@ static void pager_layer_deinit(void) {
 }
 
 static void refresh_layer_init(void) {
-    refresh_layer = refresh_layer_create(GRect(TEXT_MARGIN, (PEBBLE_HEIGHT - REFRESH_LAYER_HEIGHT) / 2, PEBBLE_WIDTH - TEXT_MARGIN * 2, REFRESH_LAYER_HEIGHT));
+    refresh_layer = refresh_layer_create(GRect(TEXT_MARGIN, (screen.size.h - REFRESH_LAYER_HEIGHT) / 2, screen.size.w - TEXT_MARGIN * 2, REFRESH_LAYER_HEIGHT));
 
     Layer *base_layer = refresh_layer_get_layer(refresh_layer);
     layer_set_hidden(base_layer, true);


### PR DESCRIPTION
Hey there! Thanks for making skunk.
Unfortunately the barcode drawing is ruined on these new watches by the automatic upscaling (they become an unscannable blurry mess).
Thankfully, patching the code to support generic screen sizes was pretty easy - so I just went ahead and did that. Should make supporting any potential future devices easier, too.

Yeah, using a global GRect for the screen size is not exactly.... clean, but it was the smallest change I thought made sense. Feel free to change it if you prefer something else, of course!